### PR TITLE
feat: manual payment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ workflows:
             branches:
               only:
                 - develop
-                - feat/reviewer-payment
+                - feat/manual-payment
 
       # Production builds are exectuted only on tagged commits to the
       # master branch.

--- a/src/dao/RegistrationDAO.js
+++ b/src/dao/RegistrationDAO.js
@@ -6,6 +6,7 @@ const RESOURCE_TYPE_EXT_REF_ID = 1
 const RESOURCE_TYPE_HANDLE_ID = 2
 const RESOURCE_TYPE_REG_DATE = 6
 const RESOURCE_TYPE_APPEALS_COMPLETED = 13
+const RESOURCE_TYPE_MANUAL_PAYMENTS = 15
 
 const RESOURCE_TYPE_COPILOT_PAYMENT_ID = 7
 const COPILOT_RESOURCE_ROLE_ID = 14
@@ -546,5 +547,6 @@ module.exports = {
   insertChallengeResult,
   getPhaseIdForPhaseTypeId,
   getResourceRoles,
-  getUseTermsOfAgree
+  getUseTermsOfAgree,
+  RESOURCE_TYPE_MANUAL_PAYMENTS
 }

--- a/src/services/ProcessorService.js
+++ b/src/services/ProcessorService.js
@@ -9,6 +9,8 @@ const helper = require('../common/helper')
 const ResourceDirectManager = require('./ResourceDirectManager')
 const ProjectServices = require('./ProjectService')
 const ProjectPaymentDAO = require('../dao/ProjectPaymentDAO')
+const RegistrationDAO = require('../dao/RegistrationDAO');
+
 const notificationService = require('./NotificationService')
 const { isStudio } = require('../common/utils')
 
@@ -225,6 +227,7 @@ async function updateResourcePayment (message) {
     if (projectPaymentId == null && reviewerPrize != null) {
       logger.info(`Add new payment for resource ${resourceId} with role ${roleId}.`)
       await ProjectPaymentDAO.persistReviewerPayment(userId, resourceId, reviewerPrize.value, config.LEGACY_PROJECT_REVIEW_PAYMENT_TYPE_ID);
+      await RegistrationDAO.persistResourceInfo(userId, resourceId, RegistrationDAO.RESOURCE_TYPE_MANUAL_PAYMENTS, 'true');
     } else {
       logger.info(`Update reviewer payment ${amount} for resource ${resourceId} with role ${roleId} and payment ${projectPaymentId} with amount ${reviewerPrize.value}`)
       await ProjectPaymentDAO.updateProjectPayment(userId, projectPaymentId, reviewerPrize.value)


### PR DESCRIPTION
* when adding resource payment from challenge metadata
* mark payment as a manual payment to prevent OR from
* overwriting the value